### PR TITLE
#167204518 Fix workspace error on boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LandvileFrontend
+# landvilleFrontend
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 8.0.3.
 

--- a/angular.json
+++ b/angular.json
@@ -3,7 +3,7 @@
   "version": 1,
   "newProjectRoot": "projects",
   "projects": {
-    "landvile-frontend": {
+    "landville-frontend": {
       "projectType": "application",
       "schematics": {
         "@schematics/angular:component": {
@@ -17,7 +17,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
-            "outputPath": "dist/landvile-frontend",
+            "outputPath": "dist/landville-frontend",
             "index": "src/index.html",
             "main": "src/main.ts",
             "polyfills": "src/polyfills.ts",

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,7 +16,7 @@ module.exports = function(config) {
       clearContext: false // leave Jasmine Spec Runner output visible in browser
     },
     coverageIstanbulReporter: {
-      dir: require('path').join(__dirname, './coverage/landvile-frontend'),
+      dir: require('path').join(__dirname, './coverage/landville-frontend'),
       reports: ['html', 'lcovonly', 'text-summary'],
       fixWebpackSourcePaths: true
     },

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>LandvileFrontend</title>
+    <title>landvilleFrontend</title>
     <base href="/" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
## Description ##
When trying to run the server, an error of  `landville-frontend could not be found in the workspace` is thrown. This PR corrects the spelling errors of the workspace in the angular.json file
## Type of change ##
Please select the relevant option
- [x] Bug fix(a non-breaking change which fixes an issue)
- [ ] New feature(a non-breaking change which adds functionality)
- [ ] Breaking change(fix of feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? ##
Please describe the tests that you ran to verify your changes
- [ ] End to end test
- [ ] Integration test
- [ ] unit test

## Checklist: ##
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

## Related Pivotal Tracker stories ##
[#167204518](https://www.pivotaltracker.com/story/show/167204518)