### PR TITLE
#168244813 Authenticated users should be able to logout of LandVille

### DIFF
--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -48,7 +48,7 @@
             >Partners</a
           >
         </li>
-        <li class="nav-item">
+        <li *ngIf="authenticated" class="nav-item">
           <a
             class="nav-link waves-effect waves-light"
             routerLink="/user/deposits"
@@ -144,8 +144,7 @@
             <a
               (click)="handleLogout()"
               class="dropdown-item waves-effect waves-light profileDropDown"
-              routerLink="/logout"
-              routerLinkActive="active"
+              id="logoutBtn"
             >
               <i class="fa fa-sign-out"></i> Log Out</a
             >

--- a/src/app/components/navbar/navbar.component.spec.ts
+++ b/src/app/components/navbar/navbar.component.spec.ts
@@ -1,43 +1,38 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { localStorageSpy, profileServiceSpy } from 'src/app/helpers/spies';
+import { localStorageSpy, profileServiceSpy, routerSpy } from 'src/app/helpers/spies';
 import { LocalStorageService } from 'src/app/services/local-storage.service';
 import { ProfileService } from 'src/app/services/profile/profile.service';
-
-import { NavbarComponent } from './navbar.component';
+import { NavbarComponent } from 'src/app/components/navbar/navbar.component';
 import { resetSpies } from 'src/app/helpers/social.spies';
 import { mockProfileResponse } from 'src/app/shared/mocks';
 import { of } from 'rxjs';
+import { Router } from '@angular/router';
+
 
 describe('NavbarComponent', () => {
   let component: NavbarComponent;
+
   let fixture: ComponentFixture<NavbarComponent>;
-  let inputEl: HTMLElement;
 
-  const response = {
-    data: {
-      profile: {
-        image: 'image',
-      }
-    }
-  };
-	beforeAll(() => {
-		resetSpies([profileServiceSpy])
-		profileServiceSpy.userProfile$ = of(mockProfileResponse)
-	}
+  beforeAll(() => {
+    resetSpies([profileServiceSpy]);
+    profileServiceSpy.userProfile$ = of(mockProfileResponse);
+  }
 
-	)
+  );
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
         HttpClientTestingModule,
       ],
       declarations: [
-				NavbarComponent
+        NavbarComponent
       ],
       providers: [
         { provide: LocalStorageService, useValue: localStorageSpy },
-				{ provide: ProfileService, useValue: profileServiceSpy },
+        { provide: ProfileService, useValue: profileServiceSpy },
+        { provide: Router, useValue: routerSpy },
       ]
     })
       .compileComponents();
@@ -45,12 +40,22 @@ describe('NavbarComponent', () => {
 
   beforeEach(() => {
     fixture = TestBed.createComponent(NavbarComponent);
-		component = fixture.componentInstance;
-		profileServiceSpy.getProfile.and.returnValue(of(mockProfileResponse))
+    component = fixture.componentInstance;
+    localStorageSpy.get.and.returnValue('token');
+    profileServiceSpy.getProfile.and.returnValue(of(mockProfileResponse));
     fixture.detectChanges();
+
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should call logout', () => {
+    const el = fixture.nativeElement.querySelector('#logoutBtn');
+    el.dispatchEvent(new Event('click'));
+    fixture.whenStable().then(() => {
+      expect(component.handleLogout).toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -1,8 +1,9 @@
-import { Component, ElementRef, HostListener, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { LocalStorageService } from 'src/app/services/local-storage.service';
 import { LoginService } from 'src/app/services/login/login.service';
 import { ProfileService } from 'src/app/services/profile/profile.service';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-navbar',
@@ -21,7 +22,8 @@ export class NavbarComponent implements OnInit, OnDestroy {
   constructor(
     private profileService: ProfileService,
     private localStorageService: LocalStorageService,
-    private eRef: ElementRef,
+    private logoutService: LoginService,
+    private router: Router
   ) {
     this.authenticated = false;
     this.firstName = '';
@@ -29,14 +31,12 @@ export class NavbarComponent implements OnInit, OnDestroy {
     this.profileImage = 'assets/img/people.png';
 
     // Check if user is authenticated
-    const token = this.localStorageService.get('token', false);
-    if (token) {
-      this.authenticated = true;
-    }
+
   }
 
   ngOnInit() {
     this.profileDetails();
+    this.setIsAuthenticated();
   }
 
   profileDetails() {
@@ -53,9 +53,28 @@ export class NavbarComponent implements OnInit, OnDestroy {
   }
 
   handleLogout() {
-    LoginService.logout();
+    this.subscription.add(
+      this.logoutService.logoutUser().subscribe(
+        _ => {
+          this.clearStorage();
+        },
+        _ => {
+          this.clearStorage();
+        }
+      ));
+  }
+  setIsAuthenticated() {
+    const token = this.localStorageService.get('token', false);
+    if (token) {
+      this.authenticated = true;
+    }
   }
 
+  clearStorage() {
+    this.localStorageService.clear();
+    this.router.navigate(['/home']);
+    this.authenticated = false;
+  }
   ngOnDestroy() {
     this.subscription.unsubscribe();
   }

--- a/src/app/guards/auth.guard.spec.ts
+++ b/src/app/guards/auth.guard.spec.ts
@@ -3,18 +3,14 @@ import { AuthGuard } from 'src/app/guards/auth.guard';
 import { AuthService } from 'src/app/services/auth.service';
 import { LocalStorageService } from 'src/app/services/local-storage.service';
 import { RouterTestingModule } from '@angular/router/testing';
+import { routerSpy } from 'src/app/helpers/spies';
 
-class MockRouter {
-  navigate(path) { }
-}
 
 describe('AuthGuard', () => {
   let MockAuthService;
-  let router;
   let guard;
   beforeEach(() => {
     MockAuthService = jasmine.createSpyObj(['isLoggedIn']);
-    router = new MockRouter();
     TestBed.configureTestingModule({
       imports: [RouterTestingModule],
       providers: [
@@ -22,7 +18,7 @@ describe('AuthGuard', () => {
         { provide: { AuthService, useValue: MockAuthService } },
       ]
     });
-    guard = new AuthGuard(MockAuthService, router);
+    guard = new AuthGuard(MockAuthService, routerSpy);
   });
 
   it(

--- a/src/app/guards/no-auth.guard.spec.ts
+++ b/src/app/guards/no-auth.guard.spec.ts
@@ -3,15 +3,13 @@ import { TestBed, inject } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NoAuthGuard } from 'src/app/guards/no-auth.guard';
 import { AuthService } from 'src/app/services/auth.service';
+import { routerSpy } from 'src/app/helpers/spies';
 
-class MockRouter {
-  navigate(path) { }
-}
 
 describe('NoAuthGuard', () => {
   let authGuard: NoAuthGuard;
   let MockAuthService;
-  let router;
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [RouterTestingModule],
@@ -20,9 +18,8 @@ describe('NoAuthGuard', () => {
         { provide: { AuthService, useValue: MockAuthService } },
       ]
     });
-    router = new MockRouter();
     MockAuthService = jasmine.createSpyObj(['isLoggedIn']);
-    authGuard = new NoAuthGuard(MockAuthService, router);
+    authGuard = new NoAuthGuard(MockAuthService, routerSpy);
   });
 
   it(

--- a/src/app/guards/no-auth.guard.ts
+++ b/src/app/guards/no-auth.guard.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { CanActivate, Router } from '@angular/router';
-import { AuthService } from '../services/auth.service';
+import { AuthService } from 'src/app/services/auth.service';
 
 @Injectable({
   providedIn: 'root'

--- a/src/app/helpers/error.interceptor.spec.ts
+++ b/src/app/helpers/error.interceptor.spec.ts
@@ -1,16 +1,18 @@
 import {TestBed} from '@angular/core/testing';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {ErrorInterceptor} from './error.interceptor';
-import {httpHandlerSpy, httpRequestSpy} from './spies';
+import {httpHandlerSpy, httpRequestSpy, localStorageSpy, routerSpy} from './spies';
 import {HttpHandler, HttpRequest} from '@angular/common/http';
 import {throwError} from 'rxjs';
 
-
 describe('ErrorInterceptor', () => {
   let errorInterceptor: ErrorInterceptor;
+  let MockLoginService;
 
   beforeEach(() => {
-    errorInterceptor = new ErrorInterceptor();
+    MockLoginService = jasmine.createSpyObj([ 'logoutUser' ]);
+
+    errorInterceptor = new ErrorInterceptor(MockLoginService, routerSpy, localStorageSpy);
 
     TestBed.configureTestingModule({
       providers: [

--- a/src/app/helpers/error.interceptor.ts
+++ b/src/app/helpers/error.interceptor.ts
@@ -1,21 +1,30 @@
 import {HttpEvent, HttpHandler, HttpInterceptor, HttpRequest} from '@angular/common/http';
 import {Injectable} from '@angular/core';
-import {Observable, throwError} from 'rxjs';
-import {LoginService} from '../services/login/login.service';
+import {Observable, throwError, Subscription} from 'rxjs';
+import {LoginService} from 'src/app/services/login/login.service';
 import {catchError} from 'rxjs/operators';
+import { Router } from '@angular/router';
+import { LocalStorageService } from 'src/app/services/local-storage.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class ErrorInterceptor implements HttpInterceptor {
+  subscription = new Subscription();
+  constructor(private loginService: LoginService, private router: Router, private localStorageService: LocalStorageService) {
+
+  }
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     return next.handle(req).pipe(catchError(err => {
       if (err.status === 401) {
         // auto logout if 401 response returned from api
-        LoginService.logout();
-        location.reload(true);
+        this.subscription.add(this.loginService.logoutUser().subscribe(_ => {
+          this.localStorageService.clear();
+          this.router.navigate(['/login']);
+        }));
       }
 
+      this.subscription.unsubscribe();
       const error = err.error || err.statusText;
       return throwError(error);
     }));

--- a/src/app/helpers/spies.ts
+++ b/src/app/helpers/spies.ts
@@ -86,3 +86,8 @@ export const httpClientSpy = jasmine.createSpyObj('HttpClient', [
   'delete',
   'request'
 ]);
+
+export const httpServiceSpy = jasmine.createSpyObj('HttpService', [
+  'makeRequestWithData',
+  'getRequestWithParams'
+]);

--- a/src/app/pages/payment/pin-payment.component.spec.ts
+++ b/src/app/pages/payment/pin-payment.component.spec.ts
@@ -8,12 +8,12 @@ import { of, throwError } from 'rxjs';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { CommonModule } from '@angular/common';
 import { NgxSpinnerModule } from 'ngx-spinner';
+import { routerSpy } from 'src/app/helpers/spies';
 
 
 describe('PinPaymentComponent', () => {
   let component: PinPaymentComponent;
   let fixture: ComponentFixture<PinPaymentComponent>;
-  const mockRouter = jasmine.createSpyObj(['navigate']);
   const mockToastr = jasmine.createSpyObj(['error']);
   const mockSpinner = jasmine.createSpyObj(['show', 'hide']);
   const mockPaymentService = jasmine.createSpyObj(['initiatePinPay', 'validatePinPay']);
@@ -36,7 +36,7 @@ describe('PinPaymentComponent', () => {
     component = fixture.componentInstance;
     fixture.detectChanges();
 
-    component = new PinPaymentComponent(mockPaymentService, mockRouter,
+    component = new PinPaymentComponent(mockPaymentService, routerSpy,
       mockSpinner, mockToastr, mockLocation, mockTitleSvc, mockActivatedRoute);
   });
 
@@ -49,7 +49,7 @@ describe('PinPaymentComponent', () => {
     expect(mockPaymentService.initiatePinPay).toHaveBeenCalled();
   });
   it('should call the navigate method', () => {
-    mockRouter.navigate.and.returnValue(of(true));
+    routerSpy.navigate.and.returnValue(of(true));
     component.onBack();
     expect(mockLocation.back).toHaveBeenCalled();
   });

--- a/src/app/pages/payment/pin-validate.component.spec.ts
+++ b/src/app/pages/payment/pin-validate.component.spec.ts
@@ -7,11 +7,11 @@ import { of, throwError } from 'rxjs';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { NgxSpinnerModule } from 'ngx-spinner';
+import { routerSpy } from 'src/app/helpers/spies';
 
 describe('PinValidateComponent', () => {
   let component: PinValidateComponent;
   let fixture: ComponentFixture<PinValidateComponent>;
-  const mockRouter = jasmine.createSpyObj(['navigate']);
   const mockRoute = jasmine.createSpyObj(['snapshot']);
   const mockToastr = jasmine.createSpyObj(['success', 'error']);
   const mockSpinner = jasmine.createSpyObj(['show', 'hide']);
@@ -35,7 +35,7 @@ describe('PinValidateComponent', () => {
     component = fixture.componentInstance;
     fixture.detectChanges();
 
-    component = new PinValidateComponent(mockRoute, mockRouter,
+    component = new PinValidateComponent(mockRoute, routerSpy,
       mockPaymentService, mockToastr, mockSpinner, mockLocation, mockTitleSvc, mockActivatedRoute);
   });
 
@@ -49,9 +49,9 @@ describe('PinValidateComponent', () => {
   }
   );
   it('should call the navigate method', () => {
-    mockRouter.navigate.and.returnValue(of(true));
+    routerSpy.navigate.and.returnValue(of(true));
     component.onBack();
-    expect(mockRouter.navigate).toHaveBeenCalled();
+    expect(routerSpy.navigate).toHaveBeenCalled();
   }
   );
   it('should toast error if PaymentService returns error.', () => {

--- a/src/app/pages/payment/tokenized-card.component.spec.ts
+++ b/src/app/pages/payment/tokenized-card.component.spec.ts
@@ -8,11 +8,11 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { CommonModule } from '@angular/common';
 import { NgxSpinnerModule } from 'ngx-spinner';
 import { TokenizedCardComponent } from './tokenized-card.component';
+import { routerSpy } from 'src/app/helpers/spies';
 
 describe('TokenizedCardComponent', () => {
   let component: TokenizedCardComponent;
   let fixture: ComponentFixture<TokenizedCardComponent>;
-  const mockRouter = jasmine.createSpyObj(['navigate']);
   const mockToastr = jasmine.createSpyObj(['error', 'success']);
   const mockSpinner = jasmine.createSpyObj(['show', 'hide']);
   const mockPaymentService = jasmine.createSpyObj(['payWithTokenizedCard']);
@@ -34,7 +34,7 @@ describe('TokenizedCardComponent', () => {
     fixture = TestBed.createComponent(TokenizedCardComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
-    component = new TokenizedCardComponent(mockPaymentService, mockRouter,
+    component = new TokenizedCardComponent(mockPaymentService, routerSpy,
       mockSpinner, mockToastr, mockLocation, mockActivatedRoute, mockTitle);
   });
 
@@ -48,9 +48,9 @@ describe('TokenizedCardComponent', () => {
   }
   );
   it('should call the navigate method', () => {
-    mockRouter.navigate.and.returnValue(of(true));
+    routerSpy.navigate.and.returnValue(of(true));
     component.onBack();
-    expect(mockRouter.navigate).toHaveBeenCalled();
+    expect(routerSpy.navigate).toHaveBeenCalled();
   }
   );
   it('should toast error if PaymentService returns error', () => {

--- a/src/app/pages/properties/properties.component.ts
+++ b/src/app/pages/properties/properties.component.ts
@@ -1,8 +1,8 @@
 import { ToastrService } from 'ngx-toastr';
 import { NgxSpinnerService } from 'ngx-spinner';
-import { PropertiesService } from './../../services/properties/properties.service';
+import { PropertiesService } from 'src/app/services/properties/properties.service';
 import { Component, OnInit } from '@angular/core';
-import { Property } from '../../models/Property';
+import { Property } from 'src/app/models/Property';
 import { Router, ActivatedRoute } from '@angular/router';
 import { Meta, Title } from '@angular/platform-browser';
 import { environment } from 'src/environments/environment.prod';

--- a/src/app/pages/terms/terms.component.spec.ts
+++ b/src/app/pages/terms/terms.component.spec.ts
@@ -1,6 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { TermsService } from '../../services/terms/terms.service'
-import { TermsPageComponent } from './terms.component';
+import { TermsService } from 'src/app/services/terms/terms.service';
+import { TermsPageComponent } from 'src/app/pages/terms/terms.component';
 
 describe('TermsPageComponent', () => {
   let component: TermsPageComponent;

--- a/src/app/services/login/login.service.ts
+++ b/src/app/services/login/login.service.ts
@@ -4,6 +4,7 @@ import { HttpMethods } from '../../config';
 import { HttpService } from '../http.service';
 
 
+
 @Injectable({
   providedIn: 'root'
 })
@@ -14,13 +15,12 @@ export class LoginService {
   constructor(private http: HttpService) {
   }
 
-  static logout() {
-    // removes user from local storage to log user out
-    localStorage.clear();
-    location.reload(true);
-  }
-
   login(loginData: any): Observable<any> {
     return this.http.makeRequestWithData(this.loginUrl, loginData, HttpMethods.POST);
+  }
+
+  logoutUser() {
+    return this.http.makeRequestWithData('/auth/logout/', null, HttpMethods.POST);
+
   }
 }


### PR DESCRIPTION
## Description ##
Authenticated users should be able log out of Landville.
A call is made to the backend to invalidate a token

## Type of change ##
Please select the relevant option
- [ ] Bug fix(a non-breaking change which fixes an issue)
- [x] New feature(a non-breaking change which adds functionality)
- [ ] Breaking change(fix of a feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? ##
Please describe the tests that you ran to verify your changes
- [ ] End to end test
- [x] Integration test
- [ ] unit test

## Checklist: ##
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes

## How can this PR be manually tested: ##
Login using the login route => /login and log out by clicking the logout button


## Any background context you want to provide? ##
Currently, we are only removing the token from local storage and reloading the page(unconventional and unacceptable - navigation should be seemless). A route also exists in the backend to ensure that tokens are invalidated upon user logout.

## Related Pivotal Tracker stories ##
[#168244813](https://www.pivotaltracker.com/story/show/168244813)
