### PR TITLE
#168242071 Redirect users to deposits page upon successful payment

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@nestjs/platform-express": "^6.0.0",
     "@nguniversal/express-engine": "^8.0.0",
     "@nguniversal/module-map-ngfactory-loader": "^8.0.0",
+    "@uiowa/digit-only": "^1.1.1",
     "angular-font-awesome": "^3.1.2",
     "angular-svg-round-progressbar": "^3.0.1",
     "angularx-social-login": "^1.2.7",

--- a/src/app/modules/features/components/payment/international-payment/international-payment.component.html
+++ b/src/app/modules/features/components/payment/international-payment/international-payment.component.html
@@ -10,7 +10,7 @@
               Card Number:
             </div>
 
-            <input formControlName="cardNo" class="form-control" [ngClass]="{
+            <input formControlName="cardNo" class="form-control" digitOnly [ngClass]="{
                 'is-invalid':
                   (form.get('cardNo').touched || form.get('cardNo').dirty) &&
                   !form.get('cardNo').valid
@@ -36,7 +36,7 @@
             <div>
               CVV Number:
             </div>
-            <input maxlength="4" formControlName="cvv" class="form-control" [ngClass]="{
+            <input maxlength="4" minlength="3" digitOnly formControlName="cvv" class="form-control" [ngClass]="{
                 'is-invalid':
                   (form.get('cvv').touched || form.get('cvv').dirty) &&
                   !form.get('cvv').valid
@@ -113,7 +113,7 @@
             <div>
               Amount <strong>(NGN)</strong>:
             </div>
-            <input formControlName="amount" class="form-control" [ngClass]="{
+            <input formControlName="amount" class="form-control" digitOnly [ngClass]="{
                 'is-invalid':
                   (form.get('amount').touched || form.get('amount').dirty) &&
                   !form.get('amount').valid
@@ -133,7 +133,7 @@
             <div>
               Billing zip:
             </div>
-            <input formControlName="billingZip" class="form-control" [ngClass]="{
+            <input formControlName="billingZip" class="form-control" digitOnly [ngClass]="{
                 'is-invalid':
                   (form.get('billingZip').touched ||
                     form.get('billingZip').dirty) &&

--- a/src/app/modules/features/components/payment/payment.component.scss
+++ b/src/app/modules/features/components/payment/payment.component.scss
@@ -37,6 +37,10 @@ button[type="submit"] {
 	float: right;
 }
 
+input.pin {
+	-webkit-text-security: disc;
+}	
+
 button {
 	background-color: #171039;
 	color: white;

--- a/src/app/modules/features/components/payment/pin-payment/pin-payment.component.html
+++ b/src/app/modules/features/components/payment/pin-payment/pin-payment.component.html
@@ -8,7 +8,7 @@
 			<form [formGroup]='cardForm'>
 				<div class="form-group">
 					<label >Card Number:
-					<input type="number" formControlName="cardNumber" name="cardNo" 
+					<input type="number" digitOnly formControlName="cardNumber" name="cardNo" 
 					class="form-control form-control-sm" [ngClass]="isInvalid('cardNumber')"
 					/>
 					<span class="invalid-feedback">
@@ -19,7 +19,7 @@
 				<div class="row">
 					<div class="col-md-6 form-group">
 						<label>Security Number:
-						<input type="number" formControlName="securityNumber" 
+						<input type="number" digitOnly formControlName="securityNumber" 
 						class="form-control form-control-sm" [ngClass]="isInvalid('securityNumber')"
 						/>
 						<span class="invalid-feedback">
@@ -29,8 +29,8 @@
 					</div>
 					<div class="col-md-6 form-group">
 						<label>PIN:
-						<input type="number" formControlName="pin" class="form-control 
-						form-control-sm" [ngClass]="isInvalid('pin')"/>
+						<input type="number" digitOnly formControlName="pin" class="form-control 
+						form-control-sm pin" [ngClass]="isInvalid('pin')"/>
 						<span class="invalid-feedback">
 							Card PIN is required.
 						</span>
@@ -68,7 +68,7 @@
 
 					<div class="form-group">
 						<label>Amount <strong>(NGN)</strong>:
-						<input type="number" formControlName="amount" class="form-control"
+						<input type="number" digitOnly formControlName="amount" class="form-control"
 						[ngClass]="{'is-invalid':  (cardForm.controls['amount'].dirty || 
 						cardForm.controls['amount'].touched) 
 						&& cardForm.controls['amount'].invalid}"

--- a/src/app/modules/features/components/payment/pin-validate/pin-validate.component.html
+++ b/src/app/modules/features/components/payment/pin-validate/pin-validate.component.html
@@ -7,7 +7,7 @@
 			<form>
 				<div class="form-group">
 					<label >OTP:</label>
-					<input type="number" [formControl]="otp" name="otp" class="form-control"
+					<input type="number" digitOnly [formControl]="otp" name="otp" class="form-control"
 					[ngClass]="{'is-invalid':  (otp.dirty || otp.touched) && otp.invalid}"
 					/>
 					<span class="invalid-feedback">

--- a/src/app/modules/features/components/payment/pin-validate/pin-validate.component.ts
+++ b/src/app/modules/features/components/payment/pin-validate/pin-validate.component.ts
@@ -51,11 +51,12 @@ export class PinValidateComponent implements OnInit {
     this.paymentService.validatePinPay(payload).subscribe(
       resp => {
         this.spinner.hide();
-        this.router.navigate(['/home']);
+        this.router.navigate(['/user/deposits']);
         this.toastr.success(resp['message']);
       },
       error => {
         this.spinner.hide();
+        this.router.navigate(['/user/deposits']);
         this.toastr.error(error['error']['message']);
       }
     );

--- a/src/app/modules/features/components/payment/tokenized-card/tokenized-card.component.html
+++ b/src/app/modules/features/components/payment/tokenized-card/tokenized-card.component.html
@@ -9,7 +9,7 @@
 			<div class="row">
 						<div class="form-group col-md-6">
 						<label>Amount <strong>(NGN)</strong>:
-						<input type="number" formControlName="amount" class="form-control"
+						<input type="number" digitOnly formControlName="amount" class="form-control"
 						[ngClass]="{'is-invalid':  (cardForm.controls['amount'].dirty || 
 						cardForm.controls['amount'].touched) 
 						&& cardForm.controls['amount'].invalid}"

--- a/src/app/modules/features/components/payment/tokenized-card/tokenized-card.component.ts
+++ b/src/app/modules/features/components/payment/tokenized-card/tokenized-card.component.ts
@@ -42,7 +42,7 @@ export class TokenizedCardComponent implements OnInit {
     this.paymentService.payWithTokenizedCard(payload).subscribe(
       resp => {
         this.spinner.hide();
-        this.router.navigate(['/home']);
+        this.router.navigate(['/user/deposits']);
         this.toastr.success(resp['message']);
       },
       error => {
@@ -53,6 +53,7 @@ export class TokenizedCardComponent implements OnInit {
         } else {
           toastMessage = typeof error.errors.detail === 'undefined' ? error.errors : error.errors.detail;
         }
+        this.router.navigate(['/user/deposits']);
         this.toastr.error(toastMessage);
       }
     );

--- a/src/app/modules/features/features.module.ts
+++ b/src/app/modules/features/features.module.ts
@@ -18,8 +18,13 @@ import { ClientsComponent } from 'src/app/modules/features/components/clients/cl
 import { TokenizedCardComponent } from 'src/app/modules/features/components/payment/tokenized-card/tokenized-card.component';
 import { PinValidateComponent } from 'src/app/modules/features/components/payment/pin-validate/pin-validate.component';
 import { PinPaymentComponent } from 'src/app/modules/features/components/payment/pin-payment/pin-payment.component';
-import { InternationalPaymentComponent } from 'src/app/modules/features/components/payment/international-payment/international-payment.component';
-import { InternationalPaymentStatusComponent } from 'src/app/modules/features/components/payment/international-payment-status/international-payment-status.component';
+import {
+  InternationalPaymentComponent
+} from 'src/app/modules/features/components/payment/international-payment/international-payment.component';
+import {
+  InternationalPaymentStatusComponent
+} from 'src/app/modules/features/components/payment/international-payment-status/international-payment-status.component';
+import { DigitOnlyModule } from '@uiowa/digit-only';
 
 @NgModule({
   imports: [
@@ -31,7 +36,8 @@ import { InternationalPaymentStatusComponent } from 'src/app/modules/features/co
     SharedModule,
     ReactiveFormsModule,
     ProfileModule,
-    HttpClientModule
+    HttpClientModule,
+    DigitOnlyModule
   ],
   declarations: [
     HomeComponent,


### PR DESCRIPTION
## Description ##
Users should be redirected to the deposits page upon making a successful payment where they can see their latest deposit.
User Pin should also be hidden and the input field should only be able to allow digits.

## Type of change ##
Please select the relevant option
- [x] Bug fix(a non-breaking change which fixes an issue)
- [ ] New feature(a non-breaking change which adds functionality)
- [ ] Breaking change(fix of a feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? ##
Please describe the tests that you ran to verify your changes
- [ ] End to end test
- [x] Integration test
- [ ] unit test

## Checklist: ##
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

## How can this PR be manually tested: ##
Make a payment using card & pin or a saved card and upon completion, the user should be redirected to the deposits page.


## Any background context you want to provide? ##
Users have been previously redirected to the home page, however, upon completion of the deposits feature it is only right that users who have successfully made deposits should be redirected to their deposits page with the latest deposit coming first in line.

## Related Pivotal Tracker stories ##
[#168242071](https://www.pivotaltracker.com/story/show/168242071)
