### PR TITLE
#168372495 Fix to enable user retrieve deposit between two specified dates

### DIFF
--- a/src/app/pages/deposits/deposits.component.html
+++ b/src/app/pages/deposits/deposits.component.html
@@ -4,9 +4,9 @@
     <div class="col-md-8">
       <div *ngIf="transactions.length !== 0; else none" class="container">
         <div class="row filter pl-3">
-          <input type="datetime-local" placeholder="Select Start Date" class="form-control"
-            [(ngModel)]="startDateVal" />
-          <input type="datetime-local" placeholder="Select End Date" class="form-control" [(ngModel)]="endDateVal" />
+          <input type="date" placeholder="Select Start Date" class="form-control" [(ngModel)]="startDateVal" />
+
+          <input type="date" placeholder="Select End Date" class="form-control" [(ngModel)]="endDateVal" />
 
           <button color="primary" (click)="onFilter()" class="btn filter-btn">
             Search


### PR DESCRIPTION
- Enable the Date Picker to work when a user needs to check their deposits within a given date

## Description ##
<!--- Tell us what this pull request does in the most simple to understand way  -->

## Type of change ##
Please select the relevant option
- [x] Bugfix(a non-breaking change which fixes an issue)
- [ ] New feature(a non-breaking change which adds functionality)
- [ ] Breaking change(fix of a feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? ##
Please describe the tests that you ran to verify your changes
- [ ] End to end test
- [ ] Integration test
- [ ] unit test

## Checklist: ##
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

## How can this PR be manually tested: ##
After setting up the project locally, click on Deposits in the navbar menu, then select a start and end dates then search. Transactions between those dates will be returned.

## Related Pivotal Tracker stories ##
[#168372495](https://www.pivotaltracker.com/story/show/168372495)
